### PR TITLE
Fix an issue that nan check generates error

### DIFF
--- a/mrfmsim/formula/polarization.py
+++ b/mrfmsim/formula/polarization.py
@@ -247,15 +247,17 @@ def rel_dpol_sat_td(Bzx, B1, ext_B_offset, ext_pts, Gamma, T2, tip_v):
 
     div = np.divide(atan_omega_f - atan_omega_i, Bzx)
 
-    # adjust the nan values to the average of the surrounding values
+    # adjust the nan values to the average of the surrounding values in x direction
     for idx in np.where(np.isnan(div))[0]:
+
         if idx == 0 or idx == len(div) - 1:
             raise ValueError(
                 "Nan values at the boundary, check the Bzx and B_offset values."
             )
         value = (div[idx + 1] + div[idx - 1]) / 2
 
-        if np.isnan(value):
+        # value can be a value or an array
+        if np.any(np.isnan(value)):
             raise ValueError(
                 "Nan value from division, check the Bzx and B_offset values."
             )

--- a/tests/test_formula/test_polarization.py
+++ b/tests/test_formula/test_polarization.py
@@ -219,6 +219,20 @@ def test_rel_dpol_sat_td_nan_division(sample_e):
         )
 
 
+def test_rel_dpol_sat_td_nan_division_array(sample_e):
+    """Test rel_dpol_sat_td raises an error if nan values are from division with array.
+    
+    The test may fail based on the numeric precision of the division.
+    """
+    Bzx = np.array([2, 0, 0, 0, -1]).reshape(5, 1, 1)
+    ext_B_offset = np.array([1, 0, 0, 0, 0, 0, 1]).reshape(7, 1, 1)
+
+    with pytest.raises(ValueError, match="Nan value from division"):
+        pol.rel_dpol_sat_td(
+            Bzx, 1.0, ext_B_offset, 1, sample_e.Gamma, sample_e.T2, 2000
+        )
+
+
 def test_rel_dpol_sat_td_without_td(sample_e):
     """Test rel_dpol_sat_td completely saturate spins if no td component.
 


### PR DESCRIPTION
## Description

Fix an issue that `real_dpol_sat_td` generates error when 3D array with nan values is applied.

## Changes Made

<!-- List the key changes made in this PR -->

- Change nan value checking of `real_dpol_sat_td`

## Type of Pull Request

<!-- Check the appropriate box by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Other (please describe):

## Testing

<!-- Describe the testing you have performed to verify your changes -->

- [x] All existing tests pass (`tox`)
- [x] Added new tests for new functionality
- [ ] Manual testing performed (describe below)



## Documentation

<!-- Check all that apply -->

- [ ] Updated docstrings for new/modified functions and classes
- [ ] Updated relevant documentation files (if applicable)
- [ ] Added usage examples (if applicable)
- [ ] Documentation builds without errors (`cd docs && make html`)

## Checklist

<!-- Check all that apply -->

- [x] Code follows PEP 8 style guidelines (use ``Black`` formatter's default settings)
- [x] Used meaningful variable and function names
- [x] Code is modular and readable
- [x] Commented code, particularly in hard-to-understand areas
- [x] Changes generate no new warnings or errors
- [x] PR focuses on a single feature or bug fix

